### PR TITLE
Adds ping and db health checks for monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "paperclip", "~> 4.3"
 gem 'aws-sdk-v1'
 gem 'zeus'
 gem 'friendly_id', '~> 5.1.0'
+gem 'new_relic_ping'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,8 @@ GEM
     multipart-post (2.0.0)
     nenv (0.2.0)
     nested_form (0.3.2)
+    new_relic_ping (0.1.2)
+      rails (>= 3.2)
     nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
     notiffany (0.0.8)
@@ -395,6 +397,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   mediawiki_api
+  new_relic_ping
   omniauth
   omniauth-facebook
   omniauth-mediawiki!

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,13 @@ module WikiPlaylist
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    NewRelicPing.configure do |c|
+      # This database check is defined for you by default if you're using ActiveRecord
+      # though you can override it by redefining it in your configuration
+      c.monitor('database') do
+        ActiveRecord::Base.connection.execute("select count(*) from schema_migrations")
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,15 @@
 Rails.application.routes.draw do
-  
+
 
   match "/404" => "errors#error404", via: [ :get, :post, :patch, :delete ]
   devise_for :users, :controllers => { :omniauth_callbacks => "callbacks"}
+
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
-  
+  mount NewRelicPing::Engine => '/status'
+
   get "/oauth-success" => "auth#auth_success"
   get "/auth/user_status" => "application#user_status"
   get "/csrf-token" => "application#csrf_meta"
-
 
   put "playlists/feature/:id" => "playlists#feature"
   root 'page#index'


### PR DESCRIPTION
This allows us to setup monitoring from newrelic (or any other service). `/status/health` will return ok if the app is running and the connection to the db is alive. `/status/ping` will return ok if the app is running (but no indication of the db status). 
